### PR TITLE
LawBody.texts() takes into account TOC

### DIFF
--- a/ja_law_parser/model.py
+++ b/ja_law_parser/model.py
@@ -3614,7 +3614,7 @@ class LawBody(
     def texts(self) -> Generator[str, None, None]:
         yield from texts_opt_text(self.law_title)
         yield from texts_opt_text(self.enact_statement)
-        # TODO toc
+        yield from texts_opt_texts(self.toc)
         yield from texts_opt_texts(self.preamble)
         yield from texts_texts(self.main_provision)
         yield from texts_opt_list_texts(self.suppl_provisions)

--- a/ja_law_parser/model.py
+++ b/ja_law_parser/model.py
@@ -3165,6 +3165,10 @@ class TOCArticle(WithArticleTitle, WithArticleCaption, tag="TOCArticle"):
     num: str = attr(name="Num")
     delete: Optional[bool] = attr(name="Delete", default=None)
 
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.article_title)
+        yield from texts_opt_text(self.article_caption)
+
 
 class TOCChapter(WithChapterTitle, WithArticleRange, tag="TOCChapter", search_mode="unordered"):
     """
@@ -3254,6 +3258,7 @@ class TOC(WithTOCAppdxTableLabels, tag="TOC", search_mode="unordered"):
         yield from texts_opt_str(self.toc_label)
         yield from texts_opt_str(self.toc_preamble_label)
         yield from texts_opt_list_texts(self.toc_parts)
+        yield from texts_opt_list_texts(self.toc_chapters)
         # TODO
 
 

--- a/ja_law_parser/model.py
+++ b/ja_law_parser/model.py
@@ -3259,6 +3259,8 @@ class TOC(WithTOCAppdxTableLabels, tag="TOC", search_mode="unordered"):
         yield from texts_opt_str(self.toc_preamble_label)
         yield from texts_opt_list_texts(self.toc_parts)
         yield from texts_opt_list_texts(self.toc_chapters)
+        yield from texts_opt_list_texts(self.toc_sections)
+        yield from texts_opt_list_texts(self.toc_articles)
         # TODO
 
 

--- a/ja_law_parser/model.py
+++ b/ja_law_parser/model.py
@@ -3094,6 +3094,10 @@ class TOCDivision(WithDivisionTitle, WithArticleRange, tag="TOCDivision"):
         article_range: 条範囲
     """
 
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.division_title)
+        yield from texts_opt_text(self.article_range)
+
 
 class TOCSubsection(WithSubsectionTitle, WithArticleRange, tag="TOCSubsection", search_mode="unordered"):
     """
@@ -3112,6 +3116,11 @@ class TOCSubsection(WithSubsectionTitle, WithArticleRange, tag="TOCSubsection", 
     delete: Optional[bool] = attr(name="Delete", default=None)
 
     toc_divisions: Optional[list[TOCDivision]] = None
+
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.subsection_title)
+        yield from texts_opt_text(self.article_range)
+        yield from texts_opt_list_texts(self.toc_divisions)
 
 
 class TOCSection(WithSectionTitle, WithArticleRange, tag="TOCSection", search_mode="unordered"):
@@ -3133,6 +3142,12 @@ class TOCSection(WithSectionTitle, WithArticleRange, tag="TOCSection", search_mo
 
     toc_subsections: Optional[list[TOCSubsection]] = None
     toc_divisions: Optional[list[TOCDivision]] = None
+
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.section_title)
+        yield from texts_opt_text(self.article_range)
+        yield from texts_opt_list_texts(self.toc_subsections)
+        yield from texts_opt_list_texts(self.toc_divisions)
 
 
 class TOCArticle(WithArticleTitle, WithArticleCaption, tag="TOCArticle"):
@@ -3169,6 +3184,11 @@ class TOCChapter(WithChapterTitle, WithArticleRange, tag="TOCChapter", search_mo
 
     toc_sections: Optional[list[TOCSection]] = None
 
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.chapter_title)
+        yield from texts_opt_text(self.article_range)
+        yield from texts_opt_list_texts(self.toc_sections)
+
 
 class TOCPart(WithPartTitle, tag="TOCPart", search_mode="unordered"):
     """
@@ -3186,6 +3206,10 @@ class TOCPart(WithPartTitle, tag="TOCPart", search_mode="unordered"):
     delete: Optional[bool] = attr(name="Delete", default=None)
 
     toc_chapters: Optional[list[TOCChapter]] = None
+
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.part_title)
+        yield from texts_opt_list_texts(self.toc_chapters)
 
 
 class TOCSupplProvision(WithSupplProvisionLabel, WithArticleRange, tag="TOCSupplProvision", search_mode="unordered"):
@@ -3225,6 +3249,12 @@ class TOC(WithTOCAppdxTableLabels, tag="TOC", search_mode="unordered"):
     toc_sections: Optional[list[TOCSection]] = None
     toc_articles: Optional[list[TOCArticle]] = None
     toc_suppl_provision: Optional[TOCSupplProvision] = None
+
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_str(self.toc_label)
+        yield from texts_opt_str(self.toc_preamble_label)
+        yield from texts_opt_list_texts(self.toc_parts)
+        # TODO
 
 
 class Preamble(BaseXmlModel, tag="Preamble"):
@@ -3786,6 +3816,11 @@ def texts_list_texts(obj: Sequence[TextsP]) -> Generator[str, None, None]:
     for elem in obj:
         for text in elem.texts():
             yield text
+
+
+def texts_opt_str(obj: Optional[str]) -> Generator[str, None, None]:
+    if obj is not None:
+        yield obj
 
 
 def texts_opt_text(obj: Optional[TextP]) -> Generator[str, None, None]:

--- a/ja_law_parser/model.py
+++ b/ja_law_parser/model.py
@@ -3230,6 +3230,12 @@ class TOCSupplProvision(WithSupplProvisionLabel, WithArticleRange, tag="TOCSuppl
     toc_articles: Optional[list[TOCArticle]] = None
     toc_chapters: Optional[list[TOCChapter]] = None
 
+    def texts(self) -> Generator[str, None, None]:
+        yield from texts_opt_text(self.suppl_provision_label)
+        yield from texts_opt_text(self.article_range)
+        yield from texts_opt_list_texts(self.toc_articles)
+        yield from texts_opt_list_texts(self.toc_chapters)
+
 
 class TOC(WithTOCAppdxTableLabels, tag="TOC", search_mode="unordered"):
     """
@@ -3261,7 +3267,7 @@ class TOC(WithTOCAppdxTableLabels, tag="TOC", search_mode="unordered"):
         yield from texts_opt_list_texts(self.toc_chapters)
         yield from texts_opt_list_texts(self.toc_sections)
         yield from texts_opt_list_texts(self.toc_articles)
-        # TODO
+        yield from texts_opt_texts(self.toc_suppl_provision)
 
 
 class Preamble(BaseXmlModel, tag="Preamble"):

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -6,6 +6,7 @@ class TestTOC:
         xml = """\
         <TOC>
           <TOCLabel>目次</TOCLabel>
+          <TOCPreambleLabel>前文</TOCPreambleLabel>
           <TOCChapter Num="1">
             <ChapterTitle>Chapter 1</ChapterTitle>
             <ArticleRange>（第一条・第二条）</ArticleRange>
@@ -22,6 +23,7 @@ class TestTOC:
         toc: TOC = TOC.from_xml(xml)
         assert toc is not None
         assert toc.toc_label == "目次"
+        assert toc.toc_preamble_label == "前文"
         assert len(toc.toc_chapters) == 2
         assert toc.toc_chapters[0].num == "1"
         assert toc.toc_chapters[0].chapter_title.text == "Chapter 1"

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -32,3 +32,12 @@ class TestTOC:
         assert toc.toc_chapters[1].chapter_title.text == "Chapter 2"
         assert toc.toc_chapters[1].article_range.text == "（第三条―第五条）"
         assert toc.toc_suppl_provision.suppl_provision_label.text == "附則"
+        assert list(toc.texts()) == [
+            "目次",
+            "前文",
+            "Chapter 1",
+            "（第一条・第二条）",
+            "Chapter 2",
+            "（第三条―第五条）",
+            "附則",
+        ]


### PR DESCRIPTION
- Implement `texts()` methods for TOC-related classes.
- Add tests for `TOC`.
- Take `TOC` into account for `LawBody.texts()`.